### PR TITLE
Make 'six' dependency explicit for 'tox', too.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,5 +5,6 @@ envlist = py26,py27,pypy,py33,py34
 deps = nose
        mox
        simplejson
+       six
        unittest2
 commands = nosetests protorpc/message_types_test.py protorpc/messages_test.py protorpc/protojson_test.py


### PR DESCRIPTION
Because 'tox' installs the sdist w/o dependencies.

[ci skip]