### PR TITLE
Fix docstrings and names in functions wrapped by @remote.method() and…

### DIFF
--- a/protorpc/remote.py
+++ b/protorpc/remote.py
@@ -106,6 +106,7 @@ import six
 
 __author__ = 'rafek@google.com (Rafe Kaplan)'
 
+import functools
 import logging
 import sys
 import threading
@@ -382,6 +383,7 @@ def method(request_type=message_types.VoidMessage,
         or is the Message class itself.
     """
 
+    @functools.wraps(method)
     def invoke_remote_method(service_instance, request):
       """Function used to replace original method.
 
@@ -425,7 +427,6 @@ def method(request_type=message_types.VoidMessage,
                                            response_type)
 
     invoke_remote_method.remote = remote_method_info
-    invoke_remote_method.__name__ = method.__name__
     return invoke_remote_method
 
   return remote_method_wrapper

--- a/protorpc/remote_test.py
+++ b/protorpc/remote_test.py
@@ -83,6 +83,7 @@ class BasicService(remote.Service):
 
   @remote.method(SimpleRequest, SimpleResponse)
   def remote_method(self, request):
+    """BasicService remote_method docstring."""
     self.request_ids.append(id(request))
     return SimpleResponse()
 
@@ -234,6 +235,12 @@ class MethodTest(test_util.TestCase):
             pass
 
       self.assertRaises(TypeError, declare)
+
+  def testDocString(self):
+    """Test that the docstring comes from the original method."""
+    service = BasicService()
+    self.assertEquals('BasicService remote_method docstring.',
+                      service.remote_method.__doc__)
 
 
 class GetRemoteMethodTest(test_util.TestCase):

--- a/protorpc/util.py
+++ b/protorpc/util.py
@@ -26,6 +26,7 @@ __author__ = ['rafek@google.com (Rafe Kaplan)',
 
 import cgi
 import datetime
+import functools
 import inspect
 import os
 import re
@@ -160,6 +161,7 @@ def positional(max_positional_args):
       has no arguments with default values.
   """
   def positional_decorator(wrapped):
+    @functools.wraps(wrapped)
     def positional_wrapper(*args, **kwargs):
       if len(args) > max_positional_args:
         plural_s = ''

--- a/protorpc/util_test.py
+++ b/protorpc/util_test.py
@@ -116,6 +116,13 @@ class UtilTest(test_util.TestCase):
         'Functions with no keyword arguments must specify max_positional_args',
         util.positional, fn)
 
+  def testDecoratedFunctionDocstring(self):
+    @util.positional(0)
+    def fn(kwonly=1):
+      """fn docstring."""
+      return [kwonly]
+    self.assertEquals('fn docstring.', fn.__doc__)
+
 
 class AcceptItemTest(test_util.TestCase):
 


### PR DESCRIPTION
… @util.positional().

Changed from doing this manually to using functools.wraps().