### PR TITLE
Switch `Field.__metaclass__` to `six.with_metaclass`.

### DIFF
--- a/protorpc/messages.py
+++ b/protorpc/messages.py
@@ -1134,19 +1134,19 @@ class FieldList(list):
     return list.insert(self, index, value)
 
 
+class _FieldMeta(type):
+
+  def __init__(cls, name, bases, dct):
+    getattr(cls, '_Field__variant_to_type').update(
+      (variant, cls) for variant in dct.get('VARIANTS', []))
+    type.__init__(cls, name, bases, dct)
+
+
 # TODO(rafek): Prevent additional field subclasses.
-class Field(object):
-
-  __variant_to_type = {}
-
-  class __metaclass__(type):
-
-    def __init__(cls, name, bases, dct):
-      getattr(cls, '_Field__variant_to_type').update(
-        (variant, cls) for variant in dct.get('VARIANTS', []))
-      type.__init__(cls, name, bases, dct)
+class Field(six.with_metaclass(_FieldMeta, object)):
 
   __initialized = False
+  __variant_to_type = {}
 
   @util.positional(2)
   def __init__(self,


### PR DESCRIPTION
There was still one `__metaclass__` hiding, which was of course ignored in
python3. Oops.

I think I'm actually going to do a version number bump after this, since we're
breaking a public interface. In principle, we could keep `Field.__metaclass__`
for people to use, but it's going to break in python3 anyway -- no reason to
mislead.

PTAL @cherba 