### PR TITLE
fix BaseException.message deprecation warning

### DIFF
--- a/protorpc/end2end_test.py
+++ b/protorpc/end2end_test.py
@@ -110,7 +110,7 @@ class EndToEndTest(webapp_test_util.EndToEndTestBase):
     try:
       self.stub.raise_application_error()
     except remote.ApplicationError as err:
-      self.assertEquals('This is an application error', err.message)
+      self.assertEquals('This is an application error', str(err))
       self.assertEquals('ERROR_NAME', err.error_name)
     else:
       self.fail('Expected application error')
@@ -119,7 +119,7 @@ class EndToEndTest(webapp_test_util.EndToEndTestBase):
     try:
       self.stub.raise_rpc_error()
     except remote.ServerError as err:
-      self.assertEquals('Internal Server Error', err.message)
+      self.assertEquals('Internal Server Error', str(err))
     else:
       self.fail('Expected server error')
 
@@ -127,7 +127,7 @@ class EndToEndTest(webapp_test_util.EndToEndTestBase):
     try:
       self.stub.raise_unexpected_error()
     except remote.ServerError as err:
-      self.assertEquals('Internal Server Error', err.message)
+      self.assertEquals('Internal Server Error', str(err))
     else:
       self.fail('Expected server error')
 
@@ -135,7 +135,7 @@ class EndToEndTest(webapp_test_util.EndToEndTestBase):
     try:
       self.stub.return_bad_message()
     except remote.ServerError as err:
-      self.assertEquals('Internal Server Error', err.message)
+      self.assertEquals('Internal Server Error', str(err))
     else:
       self.fail('Expected server error')
 

--- a/protorpc/webapp/service_handlers.py
+++ b/protorpc/webapp/service_handlers.py
@@ -429,7 +429,7 @@ class ServiceHandler(webapp.RequestHandler):
 
     response_message.append('Service %s\n\n' % definition_name)
     response_message.append('More about ProtoRPC: ')
-      
+
     response_message.append('http://code.google.com/p/google-protorpc\n')
     self.response.out.write(util.pad_string(''.join(response_message)))
 
@@ -603,7 +603,7 @@ class ServiceHandler(webapp.RequestHandler):
       except remote.ApplicationError as err:
         self.__send_error(400,
                           remote.RpcState.APPLICATION_ERROR,
-                          err.message,
+                          str(err),
                           mapper,
                           err.error_name)
         return

--- a/protorpc/wsgi/service.py
+++ b/protorpc/wsgi/service.py
@@ -184,7 +184,7 @@ def service_mapping(service_factory, service_path=r'.*', protocols=None):
     except remote.ApplicationError as err:
       return send_rpc_error(six.moves.http_client.BAD_REQUEST,
                             remote.RpcState.APPLICATION_ERROR,
-                            err.message,
+                            str(err),
                             err.error_name)
     except Exception as err:
       logging.exception('Encountered unexpected error from ProtoRPC '


### PR DESCRIPTION
This fixes the warning: 
...protorpc/wsgi/service.py:186: DeprecationWarning: BaseException.message has been deprecated as of Python 2.6

Ultimately, I'm hoping this can eventually make it back to a Google App Engine release, to fix this issue:
https://code.google.com/p/googleappengine/issues/detail?id=10842
I'm not sure if this code is actually ever considered for incorporation into the official releases, as this repo is particularly light on documentation, but I'd love to know more about that process.

Caveat: I tried for quite a while to actually run the unit test I edited and was ultimately unsuccessful, as I could not get it to successfully resolve the ProtocolBuffer class.  I did notice that the automated unit tests for this repo don't even run this test, so perhaps there is some dependency that needs to be brought in for that.  That said, I did run these changes manually in my local copy of appengine, and they do work in preventing the deprecation warning without any ill side effects as far as I can tell.  If anyone can suggest how to run the end2end_test.py here, that would be much appreciated.

FYI, it looks like the one open issue (#8) in this repo is complaining about the same thing I ran into while trying to run the tests here.

Hope this is helpful in some way.
