### PR TITLE
Better unicode handling in error formatting.

### DIFF
--- a/protorpc/end2end_test.py
+++ b/protorpc/end2end_test.py
@@ -110,7 +110,7 @@ class EndToEndTest(webapp_test_util.EndToEndTestBase):
     try:
       self.stub.raise_application_error()
     except remote.ApplicationError as err:
-      self.assertEquals('This is an application error', str(err))
+      self.assertEquals('This is an application error', unicode(err))
       self.assertEquals('ERROR_NAME', err.error_name)
     else:
       self.fail('Expected application error')
@@ -119,7 +119,7 @@ class EndToEndTest(webapp_test_util.EndToEndTestBase):
     try:
       self.stub.raise_rpc_error()
     except remote.ServerError as err:
-      self.assertEquals('Internal Server Error', str(err))
+      self.assertEquals('Internal Server Error', unicode(err))
     else:
       self.fail('Expected server error')
 
@@ -127,7 +127,7 @@ class EndToEndTest(webapp_test_util.EndToEndTestBase):
     try:
       self.stub.raise_unexpected_error()
     except remote.ServerError as err:
-      self.assertEquals('Internal Server Error', str(err))
+      self.assertEquals('Internal Server Error', unicode(err))
     else:
       self.fail('Expected server error')
 
@@ -135,7 +135,7 @@ class EndToEndTest(webapp_test_util.EndToEndTestBase):
     try:
       self.stub.return_bad_message()
     except remote.ServerError as err:
-      self.assertEquals('Internal Server Error', str(err))
+      self.assertEquals('Internal Server Error', unicode(err))
     else:
       self.fail('Expected server error')
 

--- a/protorpc/remote.py
+++ b/protorpc/remote.py
@@ -264,7 +264,7 @@ class ApplicationError(RpcError):
     self.error_name = error_name
 
   def __str__(self):
-    return self.args[0]
+    return self.args[0] or ''
 
   def __repr__(self):
     if self.error_name is None:

--- a/protorpc/webapp/service_handlers.py
+++ b/protorpc/webapp/service_handlers.py
@@ -603,7 +603,7 @@ class ServiceHandler(webapp.RequestHandler):
       except remote.ApplicationError as err:
         self.__send_error(400,
                           remote.RpcState.APPLICATION_ERROR,
-                          str(err),
+                          unicode(err),
                           mapper,
                           err.error_name)
         return

--- a/protorpc/wsgi/service.py
+++ b/protorpc/wsgi/service.py
@@ -184,7 +184,7 @@ def service_mapping(service_factory, service_path=r'.*', protocols=None):
     except remote.ApplicationError as err:
       return send_rpc_error(six.moves.http_client.BAD_REQUEST,
                             remote.RpcState.APPLICATION_ERROR,
-                            str(err),
+                            unicode(err),
                             err.error_name)
     except Exception as err:
       logging.exception('Encountered unexpected error from ProtoRPC '
@@ -265,4 +265,3 @@ def service_mappings(services, registry_path=DEFAULT_REGISTRY_PATH):
       registry.RegistryService.new_factory(registry_map), registry_path))
 
   return wsgi_util.first_found(final_mapping)
-


### PR DESCRIPTION
This just switches `str(err)` to `unicode(err)` in a few places, to better handle non-ascii error messages.

PTAL @ubragg 